### PR TITLE
Add pypi support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ the pre-release identifier or local version segment::
     --pre TEXT      Set the pre-release identifier
     --local TEXT    Set the local version segment
     --canonicalize  Canonicalize the new version
+    --pypi          Get latest information about version from pypi.org
     --help          Show this message and exit.
 
 The `--reset` option should be used alongside with minor or major bump.

--- a/bump.py
+++ b/bump.py
@@ -64,7 +64,9 @@ class SemVer(object):
             major=int(major), minor=int(minor), patch=int(patch), pre=pre, local=local
         )
 
-    def bump(self, major=False, minor=False, patch=False, pre=None, local=None, reset=False):
+    def bump(
+        self, major=False, minor=False, patch=False, pre=None, local=None, reset=False
+    ):
         if major:
             self.major += 1
             if reset:
@@ -107,9 +109,7 @@ def find_name(input_string):
 
 
 def get_latest_version(name):
-    response = requests.get(
-        "https://pypi.org/pypi/{}/json".format(name)
-    ).json()
+    response = requests.get("https://pypi.org/pypi/{}/json".format(name)).json()
     return response["info"]["version"]
 
 
@@ -151,7 +151,9 @@ def get_latest_version(name):
 @click.option(
     "--canonicalize", flag_value=True, default=None, help="Canonicalize the new version"
 )
-@click.option("--pypi", flag_value=True, default=None, help="Get latest version from pypi.org")
+@click.option(
+    "--pypi", flag_value=True, default=None, help="Get latest version from pypi.org"
+)
 @click.argument("input", type=click.File("rb"), default=None, required=False)
 @click.argument("output", type=click.File("wb"), default=None, required=False)
 def main(input, output, major, minor, patch, reset, pre, local, canonicalize, pypi):

--- a/bump.py
+++ b/bump.py
@@ -12,7 +12,7 @@ import click
 from first import first
 from packaging.utils import canonicalize_version
 
-pattern = re.compile(r"((?:__)?version(?:__)? ?= ?[\"'])(.+?)([\"'])")
+version_pattern = re.compile(r"((?:__)?version(?:__)? ?= ?[\"'])(.+?)([\"'])")
 name_pattern = re.compile(r"((?:__)?name(?:__)? ?= ?[\"'])(.+?)([\"'])")
 
 
@@ -64,9 +64,7 @@ class SemVer(object):
             major=int(major), minor=int(minor), patch=int(patch), pre=pre, local=local
         )
 
-    def bump(
-            self, major=False, minor=False, patch=False, pre=None, local=None, reset=False
-    ):
+    def bump(self, major=False, minor=False, patch=False, pre=None, local=None, reset=False):
         if major:
             self.major += 1
             if reset:
@@ -90,8 +88,12 @@ class NoVersionFound(Exception):
     pass
 
 
+class NoNameFound(Exception):
+    pass
+
+
 def find_version(input_string):
-    match = first(pattern.findall(input_string))
+    match = first(version_pattern.findall(input_string))
     if match is None:
         raise NoVersionFound
     return match[1]
@@ -100,7 +102,7 @@ def find_version(input_string):
 def find_name(input_string):
     match = first(name_pattern.findall(input_string))
     if match is None:
-        raise NoVersionFound
+        raise NoNameFound
     return match[1]
 
 
@@ -178,7 +180,7 @@ def main(input, output, major, minor, patch, reset, pre, local, canonicalize, py
     version_string = str(version)
     if canonicalize:
         version_string = canonicalize_version(version_string)
-    new = pattern.sub("\g<1>{}\g<3>".format(version_string), contents)
+    new = version_pattern.sub("\g<1>{}\g<3>".format(version_string), contents)
     output.write(new.encode())
     click.echo(version_string)
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="bump",
-    version="1.3.1",
+    version="1.4.0",
     description="Bumps package version numbers",
     long_description=open("README.rst").read(),
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "configparser ; python_version<'3'",
         "first",
         "packaging>=17.1",
-        "requests"
+        "requests",
     ],
     entry_points={"console_scripts": ["bump = bump:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name="bump",
-    version="1.3.0",
+    version="1.3.1",
     description="Bumps package version numbers",
     long_description=open("README.rst").read(),
     license="MIT",
@@ -28,6 +28,7 @@ setup(
         "configparser ; python_version<'3'",
         "first",
         "packaging>=17.1",
+        "requests"
     ],
     entry_points={"console_scripts": ["bump = bump:main"]},
 )


### PR DESCRIPTION
Add arg `--pypi`: `Get latest information about version from pypi.org`. Can be handy if you don't want to truck build numbers, only `major & minor` versions. 

How it works:
```text
local   |   pypi.org  |  after update 
1.2.9   |    1.3.0    |  -> 1.3.1
1.3.0   |    1.3.0    |  -> 1.3.1
1.3.0   |    1.3.1    |  -> 1.3.2
1.4.0   |    1.3.0    |  -> 1.4.0
```